### PR TITLE
Fix min cluster size greater than one error

### DIFF
--- a/agora_topic_modeling/code/topic_modeling.py
+++ b/agora_topic_modeling/code/topic_modeling.py
@@ -28,7 +28,8 @@ def get_lightweight_bertopic_model(X: pd.Series)-> tuple[BERTopic, pd.DataFrame]
         TfidfVectorizer(),
         TruncatedSVD(100)
     )
-    topic_model = BERTopic(embedding_model=pipe, vectorizer_model=vectorizer_model, language="french", verbose=True)
+    nr_topics = 10
+    topic_model = BERTopic(embedding_model=pipe, vectorizer_model=vectorizer_model, nr_topics=nr_topics, language="french", verbose=True)
     print("Fit Transform")
     topics, probs = topic_model.fit_transform(X)
     print("Returns")
@@ -46,7 +47,7 @@ def get_custom_bertopic_model(X: pd.Series, nr_topics: int=10, min_topic_size: i
     if not sub_topics:
         print("Topic model")
         #topic_model = BERTopic(embedding_model=embedding_model, vectorizer_model=vectorizer_model, nr_topics=nr_topics, min_topic_size=min_topic_size, language="french", verbose=True)
-        topic_model = BERTopic(vectorizer_model=vectorizer_model, language="french", verbose=True)
+        topic_model = BERTopic(vectorizer_model=vectorizer_model, nr_topics=nr_topics, language="french", verbose=True)
     else:
         print("SubTopic model")
         n_docs = 2 if round(X.size * 0.02) < 2 else round(X.size * 0.02)

--- a/agora_topic_modeling/code/topic_modeling.py
+++ b/agora_topic_modeling/code/topic_modeling.py
@@ -29,7 +29,8 @@ def get_lightweight_bertopic_model(X: pd.Series)-> tuple[BERTopic, pd.DataFrame]
         TruncatedSVD(100)
     )
     nr_topics = 10
-    topic_model = BERTopic(embedding_model=pipe, vectorizer_model=vectorizer_model, nr_topics=nr_topics, language="french", verbose=True)
+    min_topic_size = 2 if round(X.size * 0.04) < 2 else round(X.size * 0.04)
+    topic_model = BERTopic(embedding_model=pipe, vectorizer_model=vectorizer_model, nr_topics=nr_topics, min_topic_size=min_topic_size, language="french", verbose=True)
     print("Fit Transform")
     topics, probs = topic_model.fit_transform(X)
     print("Returns")

--- a/agora_topic_modeling/code/topic_modeling.py
+++ b/agora_topic_modeling/code/topic_modeling.py
@@ -52,7 +52,7 @@ def get_custom_bertopic_model(X: pd.Series, nr_topics: int=10, min_topic_size: i
         topic_model = BERTopic(vectorizer_model=vectorizer_model, nr_topics=nr_topics, language="french", verbose=True)
     else:
         print("SubTopic model")
-        n_docs = round(X.size * 0.02)
+        n_docs = 2 if round(X.size * 0.02) < 2 else round(X.size * 0.02)
         topic_model = BERTopic(vectorizer_model=vectorizer_model, min_topic_size=n_docs, language="french")
     
     print("Fit Transform")

--- a/agora_topic_modeling/code/topic_modeling.py
+++ b/agora_topic_modeling/code/topic_modeling.py
@@ -28,9 +28,7 @@ def get_lightweight_bertopic_model(X: pd.Series)-> tuple[BERTopic, pd.DataFrame]
         TfidfVectorizer(),
         TruncatedSVD(100)
     )
-    nr_topics = 10
-    min_topic_size = 100
-    topic_model = BERTopic(embedding_model=pipe, vectorizer_model=vectorizer_model, nr_topics=nr_topics, min_topic_size=min_topic_size, language="french", verbose=True)
+    topic_model = BERTopic(embedding_model=pipe, vectorizer_model=vectorizer_model, language="french", verbose=True)
     print("Fit Transform")
     topics, probs = topic_model.fit_transform(X)
     print("Returns")
@@ -42,14 +40,13 @@ def get_custom_bertopic_model(X: pd.Series, nr_topics: int=10, min_topic_size: i
     print("Vectorized model")
     vectorizer_model = CountVectorizer(stop_words=stopwords.words("french"), strip_accents="ascii")
     #embedding_model = SentenceTransformer("/Users/theo.santos/Documents/Missions/Agora/models")
-
     #cluster_model = KMeans(n_clusters=5)
     
     #nr_topics = "auto"
     if not sub_topics:
         print("Topic model")
         #topic_model = BERTopic(embedding_model=embedding_model, vectorizer_model=vectorizer_model, nr_topics=nr_topics, min_topic_size=min_topic_size, language="french", verbose=True)
-        topic_model = BERTopic(vectorizer_model=vectorizer_model, nr_topics=nr_topics, language="french", verbose=True)
+        topic_model = BERTopic(vectorizer_model=vectorizer_model, language="french", verbose=True)
     else:
         print("SubTopic model")
         n_docs = 2 if round(X.size * 0.02) < 2 else round(X.size * 0.02)


### PR DESCRIPTION
From the bertopic docs:

> `min_topic_size`: The minimum size of the topic. Increasing this value will lead to a lower number of clusters/topics and vice versa. It is the same parameter as min_cluster_size in HDBSCAN. NOTE: This param will not be used if you are hdbscan_model.

> `nr_topics`: Specifying the number of topics will reduce the initial number of topics to the value specified. This reduction can take a while as each reduction in topics (-1) activates a c-TF-IDF calculation. If this is set to None, no reduction is applied. Use "auto" to automatically reduce topics using HDBSCAN. NOTE: Controlling the number of topics is best done by adjusting min_topic_size first before adjusting this parameter.

Je pense donc qu'il faudrait ajuster le `min_topic_size` en fonction du nombre de réponses (un peu comme fait pour les subtopics) tout en s'assurant que ces nombres ne tombent pas sous 2 ou supérieur au nb de réponses s'il y a peu de réponses. Cela peut valoir le coup de tester plusieurs valeurs à la place des floats que j'ai hardcodés pour voir ce qui fonctionne ne mieux en fonction de la donnée.